### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,13 +6,13 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Pangodream_18650_CL KEYWORD1
+Pangodream_18650_CL	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-getBatteryChargeLevel KEYWORD2
-getBatteryVolts KEYWORD2
-getAnalogPin KEYWORD2
-pinRead KEYWORD2
-getConvFactor KEYWORD2
+getBatteryChargeLevel	KEYWORD2
+getBatteryVolts	KEYWORD2
+getAnalogPin	KEYWORD2
+pinRead	KEYWORD2
+getConvFactor	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords